### PR TITLE
Remove unreachable code

### DIFF
--- a/lib/im/loader.rb
+++ b/lib/im/loader.rb
@@ -509,7 +509,6 @@ module Im
               raise Error,
                 "loader\n\n#{pretty_inspect}\n\nwants to manage directory #{dir}," \
                 " which is already managed by\n\n#{loader.pretty_inspect}\n"
-              EOS
             end
           end
         end


### PR DESCRIPTION
It appears that `EOS` is not defined nor not reachable.

Same fix in zeitwerk https://github.com/fxn/zeitwerk/pull/266