### PR TITLE
Allow setting different namespace root

### DIFF
--- a/lib/im/error.rb
+++ b/lib/im/error.rb
@@ -19,6 +19,9 @@ module Im
     end
   end
 
+  class SetupFinished < Error
+  end
+
   class InvalidModuleName < Error
   end
 end

--- a/lib/im/kernel.rb
+++ b/lib/im/kernel.rb
@@ -18,7 +18,11 @@ module Kernel
         if loaded = !$LOADED_FEATURES.include?(feature_path)
           $LOADED_FEATURES << feature_path
           begin
-            load path, loader.root
+            if loader.root == Object
+              load path
+            else
+              load path, loader.root
+            end
           rescue => e
             $LOADED_FEATURES.delete(feature_path)
             raise e

--- a/lib/im/kernel.rb
+++ b/lib/im/kernel.rb
@@ -18,7 +18,7 @@ module Kernel
         if loaded = !$LOADED_FEATURES.include?(feature_path)
           $LOADED_FEATURES << feature_path
           begin
-            load path, loader
+            load path, loader.root
           rescue => e
             $LOADED_FEATURES.delete(feature_path)
             raise e

--- a/lib/im/loader/config.rb
+++ b/lib/im/loader/config.rb
@@ -81,7 +81,7 @@ module Im::Loader::Config
   attr_reader :on_unload_callbacks
   private :on_unload_callbacks
 
-  def initialize
+  def initialize(root: self)
     @inflector              = Im::Inflector.new
     @logger                 = self.class.default_logger
     @tag                    = SecureRandom.hex(3)

--- a/test/lib/im/test_different_root.rb
+++ b/test/lib/im/test_different_root.rb
@@ -11,4 +11,16 @@ class TestDifferentRoot < LoaderTest
       assert mod::Foo
     end
   end
+
+  test "setting Object as root" do
+    on_teardown { remove_const :Foo, from: Object }
+
+    files = [["foo.rb", "module Foo; end"]]
+
+    @loader = new_loader(root: Object, setup: false)
+
+    with_setup(files) do
+      assert ::Foo
+    end
+  end
 end

--- a/test/lib/im/test_different_root.rb
+++ b/test/lib/im/test_different_root.rb
@@ -1,0 +1,14 @@
+require "test_helper"
+
+class TestDifferentRoot < LoaderTest
+  test "setting a different root for loader" do
+    files = [["foo.rb", "module Foo; end"]]
+
+    mod = Module.new
+    @loader = new_loader(root: mod, setup: false)
+
+    with_setup(files) do
+      assert mod::Foo
+    end
+  end
+end

--- a/test/support/loader_test.rb
+++ b/test/support/loader_test.rb
@@ -9,10 +9,11 @@ class LoaderTest < Minitest::Test
     @loader = new_loader(setup: false)
   end
 
-  def new_loader(dirs: [], enable_reloading: true, setup: true)
+  def new_loader(dirs: [], enable_reloading: true, setup: true, root: nil)
     Im::Loader.new.tap do |loader|
       Array(dirs).each { |dir| loader.push_dir(dir) }
       loader.enable_reloading if enable_reloading
+      loader.root = root      if root
       loader.setup            if setup
     end
   end


### PR DESCRIPTION
Currently the root for any loaded namespace is the loader instance. But someone may want to set autoloads on another (named or anonymous) module, and there is no reason Im should not support this.

With this change, it is now possible to pass a `root` when initializing a loader. This root (a module) is then used in place of the loader itself as the root of the (auto)loaded namespace.

e.g.

```ruby
mod = Module.new
loader = Im::Loader.new(root: mod)
loader.push_dir(...)
loader.setup
```

Now, autoloads are set on `mod` instead of `loader`. Passing `Object` as `root` here makes Im act like Zeitwerk.